### PR TITLE
Corrected 'pseudo' typo

### DIFF
--- a/src/assets/snippets/css/not-selector.md
+++ b/src/assets/snippets/css/not-selector.md
@@ -1,6 +1,6 @@
 ### :not selector
 
-The `:not` psuedo selector is useful for styling a group of elements, while leaving the last (or specified) element unstyled.
+The `:not` pseudo selector is useful for styling a group of elements, while leaving the last (or specified) element unstyled.
 
 #### HTML
 

--- a/src/assets/snippets/react/Toggle.md
+++ b/src/assets/snippets/react/Toggle.md
@@ -4,12 +4,12 @@ Renders a toggle component.
 
 Use the `React.useState()` to initialize the `isToggleOn` state variable to `false`.
 Use an object, `style`, to hold the styles for individual components and their states.
-Return a `<button>` that alters the component's `isToggledOn` when its `onClick` event is fired and determine the appearance of the content based on `isToggleOn`, applying the appropriate CSS rules from the `style` object.
+Return a `<button>` that alters the component's `isToggleOn` when its `onClick` event is fired and determine the appearance of the content based on `isToggleOn`, applying the appropriate CSS rules from the `style` object.
 
 ```jsx
 function Toggle(props) {
   const [isToggleOn, setIsToggleOn] = React.useState(false);
-  style = {
+  const style = {
     on: {
       backgroundColor: "green"
     },


### PR DESCRIPTION
- Corrected 'pseudo' typo
- Fixed typo + missing const