### PR TITLE
Fix wrong import css name in saved-tab

### DIFF
--- a/src/js/pages/saved-tab/SavedTab.js
+++ b/src/js/pages/saved-tab/SavedTab.js
@@ -19,7 +19,7 @@ import {
 } from '../../api/storage';
 import {THEMES_VARIANTS} from '../../lib/consts';
 
-import './savedTab.css';
+import './SavedTab.css';
 
 const CLASS = 'sok-SavedTab';
 


### PR DESCRIPTION
Wrong import name of css file in SavedTab.js. It makes compile failure.

original: 
```js 
	import './savedTab.css';
```

fix: 
```js 
	import './SavedTab.css';
```