### PR TITLE
Fixed: typos

### DIFF
--- a/src/assets/snippets/react/Ticker.md
+++ b/src/assets/snippets/react/Ticker.md
@@ -28,9 +28,9 @@ function Ticker(props) {
 
   return (
     <div>
-      <span style={{ fontSize: 100 }}>{this.state.ticker}</span>
-      <button onClick={this.tick}>Tick!</button>
-      <button onClick={this.reset}>Reset</button>
+      <span style={{ fontSize: 100 }}>{ticker}</span>
+      <button onClick={tick}>Tick!</button>
+      <button onClick={reset}>Reset</button>
     </div>
   );
 }


### PR DESCRIPTION
In this PR, I've removed this and this.state keywords from ticker code snippet return statement because there is no "this" in functional components