### PR TITLE
Clarify that a number as a string should be passed into toOrdinalSuffix

### DIFF
--- a/src/assets/snippets/javascript/toOrdinalSuffix.md
+++ b/src/assets/snippets/javascript/toOrdinalSuffix.md
@@ -7,8 +7,8 @@ Find which ordinal pattern digits match.
 If digit is found in teens pattern, use teens ordinal.
 
 ```js
-const toOrdinalSuffix = num => {
-  const int = parseInt(num),
+const toOrdinalSuffix = numString => {
+  const int = parseInt(numString, 10),
     digits = [int % 10, int % 100],
     ordinals = ['st', 'nd', 'rd', 'th'],
     oPattern = [1, 2, 3, 4],


### PR DESCRIPTION
Supplying a number with a leading zero would cause the number to be interpreted as base 8.

```js
toOrdinalSuffix(010) // 8th
toOrdinalSuffix('010') // 10th
```

Just makes it a little more clear that the input should be a string, not a number. 

Lemme know if you'd prefer the solution to do input cleaning or throw a warning instead. I didn't add it because I think it takes away from the core part of the example.