### PR TITLE
Adjust the container width in lower resolutions

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -93,7 +93,7 @@
 	/* Content */
 
 	--content__width--max: 1024px;
-	--content__width: calc(100vw - 480px);
+	--content__width: calc(100vw - 80px);
 }
 
 /* Global */


### PR DESCRIPTION
To fix the issue #38 I make a small adjustment on the container width.

This gif was generated in a full hd resolution monitor.

![30_seconds](https://user-images.githubusercontent.com/1998649/54281419-7a320000-4578-11e9-8c5f-3bf6c063b9ed.gif)