### PR TITLE
Adding feature to log and show the last 5 snippets seen

### DIFF
--- a/src/js/api/snippets.js
+++ b/src/js/api/snippets.js
@@ -1,5 +1,10 @@
 import {randArrayItem} from '../lib/random';
-import {restoreFromStorage, restoreBlacklistedSnippetFromStorage} from './storage';
+import {
+        lastSeenSnippetsToStorage,
+        restoreBlacklistedSnippetFromStorage,
+        restoreLastSeenSnippetFromStorage,
+	    restoreFromStorage,
+} from './storage';
 
 /**
  * Available snippet library types
@@ -151,8 +156,16 @@ export const fetchRandomSnippet = async () => {
 		src => !blacklistedSnippets.includes(src)
 	);
 	const randomSnippet = randArrayItem(snippetSources);
+	let snippet = await fetchSnippet(randomSnippet, randomLibrary);
 
-	return await fetchSnippet(randomSnippet, randomLibrary);
+	// Log loaded snippet into history
+	const {snp, language, language_label, src, title} = snippet;
+	const loggedSnippet = await restoreLastSeenSnippetFromStorage();
+	loggedSnippet.splice(0, 0, {src, title, language}); //push front
+	loggedSnippet.splice(5); //leave the first 5
+	await lastSeenSnippetsToStorage(loggedSnippet);
+
+	return snippet;
 };
 
 /**

--- a/src/js/api/snippets.js
+++ b/src/js/api/snippets.js
@@ -159,9 +159,14 @@ export const fetchRandomSnippet = async () => {
 	let snippet = await fetchSnippet(randomSnippet, randomLibrary);
 
 	// Log loaded snippet into history
-	const {snp, language, language_label, src, title} = snippet;
+	const {language, snippet_src, snippet_title} = snippet;
+	const snippetToLog = {
+		src: snippet_src,
+		title: snippet_title,
+		language,
+	};
 	const loggedSnippet = await restoreLastSeenSnippetFromStorage();
-	loggedSnippet.splice(0, 0, {src, title, language}); //push front
+	loggedSnippet.splice(0, 0, snippetToLog); //push front
 	loggedSnippet.splice(5); //leave the first 5
 	await lastSeenSnippetsToStorage(loggedSnippet);
 

--- a/src/js/api/storage.js
+++ b/src/js/api/storage.js
@@ -57,6 +57,15 @@ export const DEFAULT_SAVED_SNIPPETS = ['snippets'];
 export const DEFAULT_BLACKLISTED_SNIPPETS = ['blacklisted_snippets'];
 
 /**
+ * Default last seen snippets
+ * @const DEFAULT_LAST_SEEN_SNIPPETS
+ * @readonly
+ */
+
+export const DEFAULT_LAST_SEEN_SNIPPETS = ['last_seen_snippets'];
+
+
+/**
  * Function that saves extension options to browserObject storage and syncs them over devices
  * @function saveToStorage
  * @return {Promise} setOptions - Promise that will set options to storage and return true once resolved
@@ -118,6 +127,33 @@ export const restoreSnippetsFromStorage = () => {
 	});
 
 	return getSnippets;
+};
+
+/**
+ * Function that logs Snippets to browserObject sync storage
+ * @function lastSeenSnippetsToStorage
+ * @return {Promise} lastSeenSnippetsToStorage - Promise that will log a snippet to storage and return
+ * true once resolved
+ */
+export const lastSeenSnippetsToStorage = last_seen_snippets => {
+	return new Promise(resolve => {
+		browserObject.storage.local.set({last_seen_snippets}, () => {
+			resolve(true);
+		});
+	});
+};
+
+/**
+ * Function that gets logged snippets from browserObject sync storage
+ * @function restoreLastSeenSnippetFromStorage
+ * @return {Promise} getSnippets - Promise that will return a list of logged snippets from storage when resolved
+ */
+export const restoreLastSeenSnippetFromStorage = () => {
+	return new Promise(resolve => {
+		browserObject.storage.local.get(DEFAULT_LAST_SEEN_SNIPPETS, ({last_seen_snippets}) => {
+			resolve(last_seen_snippets || []);
+		});
+	});
 };
 
 /**

--- a/src/js/pages/saved-tab/SavedTab.js
+++ b/src/js/pages/saved-tab/SavedTab.js
@@ -17,6 +17,7 @@ import {
 	openView,
 	restoreBlacklistedSnippetFromStorage,
 	restoreFromStorage,
+	restoreLastSeenSnippetFromStorage,
 	restoreSnippetsFromStorage,
 	saveSnippetsToStorage,
 } from '../../api/storage';
@@ -37,6 +38,10 @@ const TABS = {
 		key: 'blacklisted',
 		title: 'Blacklisted Snippets',
 	},
+	lastSeen: {
+		key: 'lastSeen',
+		title: 'Last Seen Snippets',
+	},
 };
 
 class SavedTab extends Component {
@@ -46,6 +51,7 @@ class SavedTab extends Component {
 		this.state = {
 			snippets: null,
 			blacklisted: null,
+			lastSeen: null,
 			theme: THEMES_VARIANTS.dark,
 			activeTab: TABS['saved'].key,
 		};
@@ -59,10 +65,12 @@ class SavedTab extends Component {
 	initSnippetsFromStorage = async () => {
 		let snippets = await restoreSnippetsFromStorage();
 		let blacklisted = await restoreBlacklistedSnippetFromStorage();
+		let lastSeen = await restoreLastSeenSnippetFromStorage();
 
 		this.setState({
 			snippets,
 			blacklisted,
+			lastSeen,
 		});
 	};
 
@@ -190,6 +198,36 @@ class SavedTab extends Component {
 		});
 	};
 
+	renderLastSeen = () => {
+		const {lastSeen} = this.state;
+
+		if (!lastSeen) {
+			return this.renderSpinner();
+		}
+
+		if (!lastSeen.length) {
+			return (
+				<div className={`${CLASS}-empty`}>
+					<img src={happyIconSrc} alt="Empty Last Seen Snippets Library" />
+					<span>Wow, there are no last seen snippets here.</span>
+					<span>Start browsing and soon this will be full :)</span>
+				</div>
+			);
+		}
+		return lastSeen.map((snippet, index) => {
+			return (
+				<div key={index} className={`${CLASS}-item`}>
+					<div className={`${CLASS}-item-title`} onClick={() => openView(index, 'lastSeen')}>
+						{snippet.title}
+					</div>
+					{this.renderLangChip(snippet.language)}
+				</div>
+			);
+		});
+
+		return snippetsItems;
+	};
+
 	handleTabChange = tab => {
 		this.setState({
 			activeTab: tab,
@@ -214,6 +252,11 @@ class SavedTab extends Component {
 					{activeTab === TABS['blacklisted'].key && (
 						<React.Fragment>
 							{this.renderBlacklisted()}
+						</React.Fragment>
+					)}
+					{activeTab === TABS['lastSeen'].key && (
+						<React.Fragment>
+							{this.renderLastSeen()}
 						</React.Fragment>
 					)}
 				</div>

--- a/src/js/pages/view-tab/ViewTab.js
+++ b/src/js/pages/view-tab/ViewTab.js
@@ -9,9 +9,10 @@ import Footer from '../../components/footer';
 import ControllsOverlay from '../../components/controlls-overlay';
 
 import {
-	restoreFromStorage,
-	restoreSnippetsFromStorage,
 	restoreBlacklistedSnippetFromStorage,
+	restoreFromStorage,
+	restoreLastSeenSnippetFromStorage,
+	restoreSnippetsFromStorage,
 } from '../../api/storage';
 import {THEMES_VARIANTS, FONT_SIZE_CLASSNAMES} from '../../lib/consts';
 import {fetchSnippet} from '../../api/snippets';
@@ -47,9 +48,9 @@ class ViewTab extends Component {
 		}
 
 		let snippets =
-			type === 'blacklisted'
-				? await restoreBlacklistedSnippetFromStorage()
-				: await restoreSnippetsFromStorage();
+			type === 'blacklisted' ? await restoreBlacklistedSnippetFromStorage() :
+			type === 'lastSeen' ?    await restoreLastSeenSnippetFromStorage() :
+					                 await restoreSnippetsFromStorage();
 
 		const {src, language} = snippets[index];
 


### PR DESCRIPTION
Based on the discussion on #45, I'm proposing a new tab on ```Saved Snippets``` that shows the user the last 5 snippets seen.
The user will see:

![30_seconds_last_seen](https://user-images.githubusercontent.com/846063/64217941-e2153380-ce95-11e9-828a-12aafee6b514.png)

Clicking on the title the user will be taken to that snippet.