### PR TITLE
Fixed scrolling always showing up when content does not need it.

### DIFF
--- a/src/js/pages/new-tab/NewTab.css
+++ b/src/js/pages/new-tab/NewTab.css
@@ -17,7 +17,7 @@
 	flex-direction: column;
 	width: var(--content__width);
 	max-width: var(--content__width--max);
-	min-height: calc(100vh - 200px);
+	min-height: calc(100vh - 256px);
 }
 
 .sok-NewTab .sok-NewTab-contentContainer .sok-NewTab-contentHeader {


### PR DESCRIPTION
Fixed the min-height of contentContainer to prevent constant scroll from showing up when content does not require scroll.

Header is 128px height + 32px margin bottom
Footer is 64px height + 32px margin top

Total is 256px of used space that needs to be removed from 100vh

